### PR TITLE
Fixed: OnsenMobileTheme - Fixed an issue where the login background does not appear

### DIFF
--- a/src/main/java/org/joget/marketplace/OnsenMobileTheme.java
+++ b/src/main/java/org/joget/marketplace/OnsenMobileTheme.java
@@ -925,4 +925,12 @@ public class OnsenMobileTheme extends AjaxUniversalTheme{
             response.setStatus(HttpServletResponse.SC_NO_CONTENT);
         }
     }
+
+    @Override
+    public String getLoginForm(Map<String, Object> data) {
+        if (!data.containsKey("loginBackground") && !this.getPropertyString("loginBackground").isEmpty()) {
+            data.put("loginBackground", "<style>#content.page_content {background-size:cover; background-image:url('" + this.getPropertyString("loginBackground") + "');}</style>");
+        }
+        return super.getLoginForm(data);
+    }
 }


### PR DESCRIPTION
### Cause(s)
This issue occurs because of how Onsen UI works. Onsen UI uses pages to display content, and these pages cover the entire viewport. When a background image is applied to the `<body>`, it won't be visible because the `<ons-page>` elements overlay the body, preventing the background from appearing.


### Change(s)
Overrode the getLoginForm() to add the bacgkround to the content inside the` <ons-page>`, rather than the body

