### PR TITLE
Fixed: Date Picker popup not fully visible at larger zoom levels and smaller screens.

### DIFF
--- a/src/main/resources/resources/css/onsenMobileCustom.css
+++ b/src/main/resources/resources/css/onsenMobileCustom.css
@@ -259,6 +259,12 @@ ons-pull-hook#pull-hook + ons-tabbar#onsenTabbar {
 .page__content:has(.datalist-body-content .filter_form.show){
     overflow: hidden;
 }
+.page__content:has(.popup-picker){
+    overflow: hidden;
+}
+body:has(.popup-picker) {
+    overflow: visible;
+}
 #content .main-body-content {
     border: 0px;
 }


### PR DESCRIPTION
### Issue causes

The bug happens because of the incorrect `overflow` visibility scope. Onsen theme has its `overflow` property being applied on the `<.page__content>` level instead of `<body>` level. Since the `<.ui-datepicker>` is located outside the `<.page__content>`, the scrolling effect does not affect the content within `<.ui-datepicker>`, thus causing the inability to view the overflowed part of the calendar.

### Changes

`:has()` psuedo class has been applied to change the `overflow` visibility scope from `<.page__content>` to `<body>` level whenever the Date Picker is triggered.